### PR TITLE
[WIP]: Initial build system and copy-over of file from openpmix/mpi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,64 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# http://www.gnu.org/software/automake
+
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+config/libtool.m4
+config/ltoptions.m4
+config/ltsugar.m4
+config/ltversion.m4
+config/lt~obsolete.m4
+
+# Generated Makefile 
+# (meta build system like autotools, 
+# can automatically generate from config.status script
+# (which is called by configure script))
+
+Makefile
+
+config/missing
+config/install-sh
+config/depcomp
+config/ar-lib
+config/ltmain.sh
+config/config.*
+libtool
+*/.libs/

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ config/ltmain.sh
 config/config.*
 libtool
 */.libs/
+
+src/include/pmix_config.h*
+src/include/stamp-h1

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = src test

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+autoreconf --install

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -1,0 +1,271 @@
+# -*- shell-script ; indent-tabs-mode:nil -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2018 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# define an internal function for checking the existence
+# and validity of an external PMIx library
+#
+# OPAL_CHECK_PMIX_LIB(installdir, libdir, [action-if-valid], [action-if-not-valid])
+AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
+
+    OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
+    opal_external_pmix_happy=no
+
+    # Make sure we have the headers and libs in the correct location
+    AC_MSG_CHECKING([for pmix.h in $1])
+    files=`ls $1/pmix.h 2> /dev/null | wc -l`
+    AS_IF([test "$files" -gt 0],
+         [AC_MSG_RESULT([found])
+          pmix_ext_install_incdir=$1
+          opal_external_pmix_header_happy=yes],
+         [AC_MSG_RESULT([not found])
+          AC_MSG_CHECKING([for pmix.h in $1/include])
+          files=`ls $1/include/pmix.h 2> /dev/null | wc -l`
+          AS_IF([test "$files" -gt 0],
+                [AC_MSG_RESULT([found])
+                 pmix_ext_install_incdir=$1/include
+                 opal_external_pmix_header_happy=yes],
+                [AC_MSG_RESULT([not found])
+                 opal_external_pmix_header_happy=no])])
+
+    AS_IF([test "$opal_external_pmix_header_happy" = "yes"],
+         [AS_IF([test -n "$2"],
+                [AC_MSG_CHECKING([libpmix.* in $2])
+                 files=`ls $2/libpmix.* 2> /dev/null | wc -l`
+                 AS_IF([test "$files" -gt 0],
+                       [AC_MSG_RESULT([found])
+                        pmix_ext_install_libdir=$2],
+                       [AC_MSG_RESULT([not found])
+                        AC_MSG_CHECKING([libpmix.* in $2/lib64])
+                        files=`ls $2/lib64/libpmix.* 2> /dev/null | wc -l`
+                        AS_IF([test "$files" -gt 0],
+                              [AC_MSG_RESULT([found])
+                               pmix_ext_install_libdir=$2/lib64],
+                              [AC_MSG_RESULT([not found])
+                               AC_MSG_CHECKING([libpmix.* in $2/lib])
+                               files=`ls $2/lib/libpmix.* 2> /dev/null | wc -l`
+                               AS_IF([test "$files" -gt 0],
+                                     [AC_MSG_RESULT([found])
+                                      pmix_ext_install_libdir=$2/lib],
+                                     [AC_MSG_RESULT([not found])
+                                      AC_MSG_ERROR([Cannot continue])])])])],
+                [# check for presence of lib64 directory - if found, see if the
+                 # desired library is present and matches our build requirements
+                 AC_MSG_CHECKING([libpmix.* in $1/lib64])
+                 files=`ls $1/lib64/libpmix.* 2> /dev/null | wc -l`
+                 AS_IF([test "$files" -gt 0],
+                       [AC_MSG_RESULT([found])
+                        pmix_ext_install_libdir=$1/lib64],
+                       [AC_MSG_RESULT([not found])
+                        AC_MSG_CHECKING([libpmix.* in $1/lib])
+                        files=`ls $1/lib/libpmix.* 2> /dev/null | wc -l`
+                        AS_IF([test "$files" -gt 0],
+                              [AC_MSG_RESULT([found])
+                               pmix_ext_install_libdir=$1/lib],
+                              [AC_MSG_RESULT([not found])
+                               AC_MSG_ERROR([Cannot continue])])])])
+
+          # check the version
+          opal_external_pmix_save_CPPFLAGS=$CPPFLAGS
+          opal_external_pmix_save_LDFLAGS=$LDFLAGS
+          opal_external_pmix_save_LIBS=$LIBS
+
+          # if the pmix_version.h file does not exist, then
+          # this must be from a pre-1.1.5 version OMPI does
+          # NOT support anything older than v1.2.5
+          AC_MSG_CHECKING([PMIx version])
+          AS_IF([test "$pmix_ext_install_incdir" != "/usr" && test "$pmix_ext_install_incdir" != "/usr/include"],
+                [CPPFLAGS="-I$pmix_ext_install_incdir $CPPFLAGS"])
+          AS_IF([test "$pmix_ext_install_libdir" != "/usr" && test "$pmix_ext_install_libdir" != "/usr/include"],
+                [LDFLAGS="-L$pmix_ext_install_libdir $LDFLAGS"])
+          LIBS="$LIBS -lpmix"
+
+          AS_IF([test "x`ls $1/include/pmix_version.h 2> /dev/null`" = "x"],
+                [AC_MSG_RESULT([version file not found - assuming v1.1.4])
+                 opal_external_pmix_version_found=1
+                 opal_external_pmix_happy=no
+                 opal_external_pmix_version=internal],
+                [AC_MSG_RESULT([version file found])
+                 opal_external_pmix_version_found=0])
+
+          # if it does exist, then we need to parse it to find
+          # the actual release series
+          AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                [AC_MSG_CHECKING([version 4x])
+                 AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                     #include <pmix_version.h>
+                                                     #if (PMIX_VERSION_MAJOR < 4L)
+                                                     #error "not version 4 or above"
+                                                     #endif
+                                                    ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=4x
+                                     opal_external_pmix_version_found=1
+                                     opal_external_pmix_happy=yes],
+                                    [AC_MSG_RESULT([not found])])])
+
+          AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                [AC_MSG_CHECKING([version 3x or above])
+                 AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                              #include <pmix_version.h>
+                                              #if (PMIX_VERSION_MAJOR != 3L)
+                                              #error "not version 3"
+                                              #endif
+                                              ], [])],
+                                   [AC_MSG_RESULT([found])
+                                    opal_external_pmix_version=3x
+                                    opal_external_pmix_version_found=1
+                                    opal_external_pmix_happy=yes],
+                                   [AC_MSG_RESULT([not found])])])
+
+          AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                [AC_MSG_CHECKING([version 2x])
+                 AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                              #include <pmix_version.h>
+                                              #if (PMIX_VERSION_MAJOR != 2L)
+                                              #error "not version 2"
+                                              #endif
+                                              ], [])],
+                                   [AC_MSG_RESULT([found])
+                                    opal_external_pmix_version=2x
+                                    opal_external_pmix_version_found=1
+                                    opal_external_pmix_happy=yes],
+                                   [AC_MSG_RESULT([not found])])])
+
+          AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                [AC_MSG_CHECKING([version 1x])
+                 AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                              #include <pmix_version.h>
+                                              #if (PMIX_VERSION_MAJOR != 1L && PMIX_VERSION_MINOR != 2L)
+                                              #error "not version 1.2.x"
+                                              #endif
+                                              ], [])],
+                                   [AC_MSG_RESULT([found])
+                                    opal_external_pmix_version=1x
+                                    opal_external_pmix_version_found=1
+                                    opal_external_have_pmix1=1
+                                    opal_external_pmix_happy=yes],
+                                   [AC_MSG_RESULT([not found])])])
+
+          AS_IF([test "x$opal_external_pmix_version" = "x"],
+                [AC_MSG_WARN([External PMIx support detected, but version])
+                 AC_MSG_WARN([information of the external lib could not])
+                 AC_MSG_WARN([be detected])
+                 opal_external_pmix_happy=no])
+
+    ])
+    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+          [$3
+           # add the new flags to our wrapper compilers
+           AS_IF([test "$pmix_ext_install_incdir" != "/usr" && test "$pmix_ext_install_incdir" != "/usr/include"],
+                 [pmix_pmix4x_WRAPPER_EXTRA_CPPFLAGS="-I$pmix_ext_install_incdir"])
+           AS_IF([test "$pmix_ext_install_libdir" != "/usr" && test "$pmix_ext_install_libdir" != "/usr/include"],
+                 [pmix_external_WRAPPER_EXTRA_LDFLAGS="-L$pmix_ext_install_libdir"])
+           pmix_external_WRAPPER_EXTRA_LIBS=-lpmix],
+          [CPPFLAGS=$opal_external_pmix_save_CPPFLAGS
+           LDFLAGS=$opal_external_pmix_save_LDFLAGS
+           LIBS=$opal_external_pmix_save_LIBS
+           $4])
+
+    OPAL_VAR_SCOPE_POP
+])
+
+
+AC_DEFUN([OPAL_CHECK_PMIX],[
+
+    AC_ARG_WITH([pmix],
+                [AC_HELP_STRING([--with-pmix(=DIR)],
+                                [Build PMIx support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of PMIx.  "external" forces Open MPI to use an external installation of PMIx.  Supplying a valid directory name also forces Open MPI to use an external installation of PMIx, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI does not support --without-pmix.])])
+
+    AC_ARG_WITH([pmix-libdir],
+                [AC_HELP_STRING([--with-pmix-libdir=DIR],
+                                [Look for libpmix in the given directory DIR, DIR/lib or DIR/lib64])])
+
+    AS_IF([test "$with_pmix" = "no"],
+          [AC_MSG_WARN([Open MPI requires PMIx support. It can be built])
+           AC_MSG_WARN([with either its own internal copy of PMIx, or with])
+           AC_MSG_WARN([an external copy that you supply.])
+           AC_MSG_ERROR([Cannot continue])])
+
+    opal_external_have_pmix1=0
+    AC_MSG_CHECKING([if user requested internal PMIx support($with_pmix)])
+    opal_external_pmix_happy=no
+    pmix_ext_install_libdir=
+    pmix_ext_install_dir=
+
+    AS_IF([test "$with_pmix" = "internal"],
+          [AC_MSG_RESULT([yes])
+           opal_external_pmix_happy=no
+           opal_external_pmix_version=internal
+           opal_enable_pmix=yes],
+
+          [AC_MSG_RESULT([no])
+           # check for external pmix lib */
+           AS_IF([test -z "$with_pmix" || test "$with_pmix" = "yes" || test "$with_pmix" = "external"],
+                 [pmix_ext_install_dir=/usr],
+                 [pmix_ext_install_dir=$with_pmix])
+           AS_IF([test -n "$with_pmix_libdir"],
+                 [pmix_ext_install_libdir=$with_pmix_libdir])
+           OPAL_CHECK_PMIX_LIB([$pmix_ext_install_dir],
+                               [$pmix_ext_install_libdir],
+                               [opal_external_pmix_happy=yes
+                                opal_enable_pmix=yes],
+                               [opal_external_pmix_happy=no])])
+
+    # Final check - if they explicitly pointed us at an external
+    # installation that wasn't acceptable, then error out
+    AS_IF([test -n "$with_pmix" && test "$with_pmix" != "yes" && test "$with_pmix" != "external" && test "$with_pmix" != "internal" && test "$opal_external_pmix_happy" = "no"],
+          [AC_MSG_WARN([External PMIx support requested, but either the version])
+           AC_MSG_WARN([of the external lib was not supported or the required])
+           AC_MSG_WARN([header/library files were not found])
+           AC_MSG_ERROR([Cannot continue])])
+
+    # Final check - if they didn't point us explicitly at an external version
+    # but we found one anyway, use the internal version if it is higher
+    AS_IF([test "$opal_external_pmix_version" != "internal" && (test -z "$with_pmix" || test "$with_pmix" = "yes")],
+          [AS_IF([test "$opal_external_pmix_version" != "4x"],
+                 [AC_MSG_WARN([discovered external PMIx version is less than internal version 4.x])
+                  AC_MSG_WARN([using internal PMIx])
+                  opal_external_pmix_version=internal
+                  opal_external_pmix_happy=no])])
+
+    AC_MSG_CHECKING([PMIx version to be used])
+    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+          [AC_MSG_RESULT([external($opal_external_pmix_version)])
+           AS_IF([test "$pmix_ext_install_dir" != "/usr"],
+                 [opal_external_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
+                  opal_external_pmix_LDFLAGS=-L$pmix_ext_install_libdir])
+           opal_external_pmix_LIBS=-lpmix],
+          [AC_MSG_RESULT([internal])])
+
+    AC_DEFINE_UNQUOTED([OPAL_PMIX_V1],[$opal_external_have_pmix1],
+                       [Whether the external PMIx library is v1])
+
+    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+          [AS_IF([test "$opal_external_pmix_version" = "1x"],
+                 [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PMIx support]], [opal_pmix], [External (1.2.5) WARNING - DYNAMIC OPS NOT SUPPORTED])],
+                 [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PMIx support]], [opal_pmix], [External ($opal_external_pmix_version)])])],
+          [OPAL_SUMMARY_ADD([[Miscellaneous]], [[PMIx support]], [opal_pmix], [Internal])])
+])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -262,10 +262,4 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
 
     AC_DEFINE_UNQUOTED([OPAL_PMIX_V1],[$opal_external_have_pmix1],
                        [Whether the external PMIx library is v1])
-
-    AS_IF([test "$opal_external_pmix_happy" = "yes"],
-          [AS_IF([test "$opal_external_pmix_version" = "1x"],
-                 [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PMIx support]], [opal_pmix], [External (1.2.5) WARNING - DYNAMIC OPS NOT SUPPORTED])],
-                 [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PMIx support]], [opal_pmix], [External ($opal_external_pmix_version)])])],
-          [OPAL_SUMMARY_ADD([[Miscellaneous]], [[PMIx support]], [opal_pmix], [Internal])])
 ])

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -98,7 +98,7 @@ OPAL_CONFIGURE_USER="${USER:-`whoami`}"
 OPAL_CONFIGURE_HOST="${HOSTNAME:-`(hostname || uname -n) 2> /dev/null | sed 1q`}"
 OPAL_CONFIGURE_DATE="`date`"
 
-OPAL_LIBNL_SANITY_INIT
+# OPAL_LIBNL_SANITY_INIT
 
 #
 # Save these details so that they can be used in opal_info later

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -1,0 +1,661 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2018 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2015-2017 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+dnl Portions of this file derived from GASNet v1.12 (see "GASNet"
+dnl comments, below)
+dnl Copyright 2004,  Dan Bonachea <bonachea@cs.berkeley.edu>
+dnl
+dnl IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+dnl DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
+dnl OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
+dnl CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+dnl
+dnl THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+dnl INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+dnl AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+dnl ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
+dnl PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+dnl
+
+AC_DEFUN([OPAL_CONFIGURE_SETUP],[
+
+# Some helper script functions.  Unfortunately, we cannot use $1 kinds
+# of arguments here because of the m4 substitution.  So we have to set
+# special variable names before invoking the function.  :-\
+
+opal_show_title() {
+  cat <<EOF
+
+============================================================================
+== ${1}
+============================================================================
+EOF
+  OPAL_LOG_MSG([=== ${1}], 1)
+}
+
+
+opal_show_subtitle() {
+  cat <<EOF
+
+*** ${1}
+EOF
+  OPAL_LOG_MSG([*** ${1}], 1)
+}
+
+
+opal_show_subsubtitle() {
+  cat <<EOF
+
++++ ${1}
+EOF
+  OPAL_LOG_MSG([+++ ${1}], 1)
+}
+
+opal_show_subsubsubtitle() {
+  cat <<EOF
+
+--- ${1}
+EOF
+  OPAL_LOG_MSG([--- ${1}], 1)
+}
+
+opal_show_verbose() {
+  if test "$V" = "1"; then
+      cat <<EOF
++++ VERBOSE: ${1}
+EOF
+      OPAL_LOG_MSG([--- ${1}], 1)
+  fi
+}
+
+#
+# Save some stats about this build
+#
+
+OPAL_CONFIGURE_USER="${USER:-`whoami`}"
+OPAL_CONFIGURE_HOST="${HOSTNAME:-`(hostname || uname -n) 2> /dev/null | sed 1q`}"
+OPAL_CONFIGURE_DATE="`date`"
+
+OPAL_LIBNL_SANITY_INIT
+
+#
+# Save these details so that they can be used in opal_info later
+#
+AC_SUBST(OPAL_CONFIGURE_USER)
+AC_SUBST(OPAL_CONFIGURE_HOST)
+AC_SUBST(OPAL_CONFIGURE_DATE)])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+AC_DEFUN([OPAL_BASIC_SETUP],[
+#
+# Save some stats about this build
+#
+
+OPAL_CONFIGURE_USER="${USER:-`whoami`}"
+OPAL_CONFIGURE_HOST="${HOSTNAME:-`(hostname || uname -n) 2> /dev/null | sed 1q`}"
+OPAL_CONFIGURE_DATE="`date`"
+
+#
+# Make automake clean emacs ~ files for "make clean"
+#
+
+CLEANFILES="*~ .\#*"
+AC_SUBST(CLEANFILES)
+
+#
+# See if we can find an old installation of OPAL to overwrite
+#
+
+# Stupid autoconf 2.54 has a bug in AC_PREFIX_PROGRAM -- if opal_clean
+# is not found in the path and the user did not specify --prefix,
+# we'll get a $prefix of "."
+
+opal_prefix_save="$prefix"
+AC_PREFIX_PROGRAM(opal_clean)
+if test "$prefix" = "."; then
+    prefix="$opal_prefix_save"
+fi
+unset opal_prefix_save
+
+#
+# Basic sanity checking; we can't install to a relative path
+#
+
+case "$prefix" in
+  /*/bin)
+    prefix="`dirname $prefix`"
+    echo installing to directory \"$prefix\"
+    ;;
+  /*)
+    echo installing to directory \"$prefix\"
+    ;;
+  NONE)
+    echo installing to directory \"$ac_default_prefix\"
+    ;;
+  @<:@a-zA-Z@:>@:*)
+    echo installing to directory \"$prefix\"
+    ;;
+  *)
+    AC_MSG_ERROR(prefix "$prefix" must be an absolute directory path)
+    ;;
+esac
+
+# BEGIN: Derived from GASNet
+
+# Suggestion from Paul Hargrove to disable --program-prefix and
+# friends.  Heavily influenced by GASNet 1.12 acinclude.m4
+# functionality to do the same thing (copyright listed at top of this
+# file).
+
+# echo program_prefix=$program_prefix  program_suffix=$program_suffix program_transform_name=$program_transform_name
+# undo prefix autoconf automatically adds during cross-compilation
+if test "$cross_compiling" = yes && test "$program_prefix" = "${target_alias}-" ; then
+    program_prefix=NONE
+fi
+# normalize empty prefix/suffix
+if test -z "$program_prefix" ; then
+    program_prefix=NONE
+fi
+if test -z "$program_suffix" ; then
+    program_suffix=NONE
+fi
+# undo transforms caused by empty prefix/suffix
+if expr "$program_transform_name" : 's.^..$' >/dev/null || \
+   expr "$program_transform_name" : 's.$$..$' >/dev/null || \
+   expr "$program_transform_name" : 's.$$..;s.^..$' >/dev/null ; then
+    program_transform_name="s,x,x,"
+fi
+if test "$program_prefix$program_suffix$program_transform_name" != "NONENONEs,x,x," ; then
+    AC_MSG_WARN([*** The Open MPI configure script does not support --program-prefix, --program-suffix or --program-transform-name. Users are recommended to instead use --prefix with a unique directory and make symbolic links as desired for renaming.])
+    AC_MSG_ERROR([*** Cannot continue])
+fi
+
+# END: Derived from GASNet
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+AC_DEFUN([OPAL_LOG_MSG],[
+# 1 is the message
+# 2 is whether to put a prefix or not
+if test -n "$2"; then
+    echo "configure:__oline__: $1" >&5
+else
+    echo $1 >&5
+fi])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+AC_DEFUN([OPAL_LOG_FILE],[
+# 1 is the filename
+if test -n "$1" && test -f "$1"; then
+    cat $1 >&5
+fi])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+AC_DEFUN([OPAL_LOG_COMMAND],[
+# 1 is the command
+# 2 is actions to do if success
+# 3 is actions to do if fail
+echo "configure:__oline__: $1" >&5
+$1 1>&5 2>&1
+opal_status=$?
+OPAL_LOG_MSG([\$? = $opal_status], 1)
+if test "$opal_status" = "0"; then
+    unset opal_status
+    $2
+else
+    unset opal_status
+    $3
+fi])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+AC_DEFUN([OPAL_UNIQ],[
+# 1 is the variable name to be uniq-ized
+opal_name=$1
+
+# Go through each item in the variable and only keep the unique ones
+
+opal_count=0
+for val in ${$1}; do
+    opal_done=0
+    opal_i=1
+    opal_found=0
+
+    # Loop over every token we've seen so far
+
+    opal_done="`expr $opal_i \> $opal_count`"
+    while test "$opal_found" = "0" && test "$opal_done" = "0"; do
+
+	# Have we seen this token already?  Prefix the comparison with
+	# "x" so that "-Lfoo" values won't be cause an error.
+
+	opal_eval="expr x$val = x\$opal_array_$opal_i"
+	opal_found=`eval $opal_eval`
+
+	# Check the ending condition
+
+	opal_done="`expr $opal_i \>= $opal_count`"
+
+	# Increment the counter
+
+	opal_i="`expr $opal_i + 1`"
+    done
+
+    # If we didn't find the token, add it to the "array"
+
+    if test "$opal_found" = "0"; then
+	opal_eval="opal_array_$opal_i=$val"
+	eval $opal_eval
+	opal_count="`expr $opal_count + 1`"
+    else
+	opal_i="`expr $opal_i - 1`"
+    fi
+done
+
+# Take all the items in the "array" and assemble them back into a
+# single variable
+
+opal_i=1
+opal_done="`expr $opal_i \> $opal_count`"
+opal_newval=
+while test "$opal_done" = "0"; do
+    opal_eval="opal_newval=\"$opal_newval \$opal_array_$opal_i\""
+    eval $opal_eval
+
+    opal_eval="unset opal_array_$opal_i"
+    eval $opal_eval
+
+    opal_done="`expr $opal_i \>= $opal_count`"
+    opal_i="`expr $opal_i + 1`"
+done
+
+# Done; do the assignment
+
+opal_newval="`echo $opal_newval`"
+opal_eval="$opal_name=\"$opal_newval\""
+eval $opal_eval
+
+# Clean up
+
+unset opal_name opal_i opal_done opal_newval opal_eval opal_count])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# OPAL_APPEND_UNIQ(variable, new_argument)
+# ----------------------------------------
+# Append new_argument to variable if not already in variable.  This assumes a
+# space separated list.
+#
+# This could probably be made more efficient :(.
+AC_DEFUN([OPAL_APPEND_UNIQ], [
+for arg in $2; do
+    opal_found=0;
+    for val in ${$1}; do
+        if test "x$val" = "x$arg" ; then
+            opal_found=1
+            break
+        fi
+    done
+    if test "$opal_found" = "0" ; then
+        if test -z "$$1"; then
+            $1="$arg"
+        else
+            $1="$$1 $arg"
+        fi
+    fi
+done
+unset opal_found
+])
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# Remove all duplicate -I, -L, and -l flags from the variable named $1
+AC_DEFUN([OPAL_FLAGS_UNIQ],[
+    # 1 is the variable name to be uniq-ized
+    opal_name=$1
+
+    # Go through each item in the variable and only keep the unique ones
+
+    opal_count=0
+    for val in ${$1}; do
+        opal_done=0
+        opal_i=1
+        opal_found=0
+
+        # Loop over every token we've seen so far
+
+        opal_done="`expr $opal_i \> $opal_count`"
+        while test "$opal_found" = "0" && test "$opal_done" = "0"; do
+
+            # Have we seen this token already?  Prefix the comparison
+            # with "x" so that "-Lfoo" values won't be cause an error.
+
+	    opal_eval="expr x$val = x\$opal_array_$opal_i"
+	    opal_found=`eval $opal_eval`
+
+            # Check the ending condition
+
+	    opal_done="`expr $opal_i \>= $opal_count`"
+
+            # Increment the counter
+
+	    opal_i="`expr $opal_i + 1`"
+        done
+
+        # Check for special cases where we do want to allow repeated
+        # arguments (per
+        # http://www.open-mpi.org/community/lists/devel/2012/08/11362.php
+        # and
+        # https://github.com/open-mpi/ompi/issues/324).
+
+        case $val in
+        -Xclang)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
+        -framework)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
+        --param)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
+        esac
+
+        # If we didn't find the token, add it to the "array"
+
+        if test "$opal_found" = "0"; then
+	    opal_eval="opal_array_$opal_i=$val"
+	    eval $opal_eval
+	    opal_count="`expr $opal_count + 1`"
+        else
+	    opal_i="`expr $opal_i - 1`"
+        fi
+    done
+
+    # Take all the items in the "array" and assemble them back into a
+    # single variable
+
+    opal_i=1
+    opal_done="`expr $opal_i \> $opal_count`"
+    opal_newval=
+    while test "$opal_done" = "0"; do
+        opal_eval="opal_newval=\"$opal_newval \$opal_array_$opal_i\""
+        eval $opal_eval
+
+        opal_eval="unset opal_array_$opal_i"
+        eval $opal_eval
+
+        opal_done="`expr $opal_i \>= $opal_count`"
+        opal_i="`expr $opal_i + 1`"
+    done
+
+    # Done; do the assignment
+
+    opal_newval="`echo $opal_newval`"
+    opal_eval="$opal_name=\"$opal_newval\""
+    eval $opal_eval
+
+    # Clean up
+
+    unset opal_name opal_i opal_done opal_newval opal_eval opal_count
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# OPAL_FLAGS_APPEND_UNIQ(variable, new_argument)
+# ----------------------------------------------
+# Append new_argument to variable if:
+#
+# - the argument does not begin with -I, -L, or -l, or
+# - the argument begins with -I, -L, or -l, and it's not already in variable
+#
+# This macro assumes a space separated list.
+AC_DEFUN([OPAL_FLAGS_APPEND_UNIQ], [
+    OPAL_VAR_SCOPE_PUSH([opal_tmp opal_append])
+
+    for arg in $2; do
+        opal_tmp=`echo $arg | cut -c1-2`
+        opal_append=1
+        AS_IF([test "$opal_tmp" = "-I" || test "$opal_tmp" = "-L" || test "$opal_tmp" = "-l"],
+              [for val in ${$1}; do
+                   AS_IF([test "x$val" = "x$arg"], [opal_append=0])
+               done])
+        AS_IF([test "$opal_append" = "1"],
+              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$$1 $arg"])])
+    done
+
+    OPAL_VAR_SCOPE_POP
+])
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# Macro that serves as an alternative to using `which <prog>`. It is
+# preferable to simply using `which <prog>` because backticks (`) (aka
+# backquotes) invoke a sub-shell which may source a "noisy"
+# ~/.whatever file (and we do not want the error messages to be part
+# of the assignment in foo=`which <prog>`). This macro ensures that we
+# get a sane executable value.
+AC_DEFUN([OPAL_WHICH],[
+# 1 is the variable name to do "which" on
+# 2 is the variable name to assign the return value to
+
+OPAL_VAR_SCOPE_PUSH([opal_prog opal_file opal_dir opal_sentinel])
+
+opal_prog=$1
+
+IFS_SAVE=$IFS
+IFS="$PATH_SEPARATOR"
+for opal_dir in $PATH; do
+    if test -x "$opal_dir/$opal_prog"; then
+        $2="$opal_dir/$opal_prog"
+        break
+    fi
+done
+IFS=$IFS_SAVE
+
+OPAL_VAR_SCOPE_POP
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# Declare some variables; use OPAL_VAR_SCOPE_POP to ensure that they
+# are cleaned up / undefined.
+AC_DEFUN([OPAL_VAR_SCOPE_PUSH],[
+
+    # Is the private index set?  If not, set it.
+    if test "x$opal_scope_index" = "x"; then
+        opal_scope_index=1
+    fi
+
+    # First, check to see if any of these variables are already set.
+    # This is a simple sanity check to ensure we're not already
+    # overwriting pre-existing variables (that have a non-empty
+    # value).  It's not a perfect check, but at least it's something.
+    for opal_var in $1; do
+        opal_str="opal_str=\"\$$opal_var\""
+        eval $opal_str
+
+        if test "x$opal_str" != "x"; then
+            AC_MSG_WARN([Found configure shell variable clash at line $LINENO!])
+            AC_MSG_WARN([[OPAL_VAR_SCOPE_PUSH] called on "$opal_var",])
+            AC_MSG_WARN([but it is already defined with value "$opal_str"])
+            AC_MSG_WARN([This usually indicates an error in configure.])
+            AC_MSG_ERROR([Cannot continue])
+        fi
+    done
+
+    # Ok, we passed the simple sanity check.  Save all these names so
+    # that we can unset them at the end of the scope.
+    opal_str="opal_scope_$opal_scope_index=\"$1\""
+    eval $opal_str
+    unset opal_str
+
+    env | grep opal_scope
+    opal_scope_index=`expr $opal_scope_index + 1`
+])dnl
+
+# Unset a bunch of variables that were previously set
+AC_DEFUN([OPAL_VAR_SCOPE_POP],[
+    # Unwind the index
+    opal_scope_index=`expr $opal_scope_index - 1`
+    opal_scope_test=`expr $opal_scope_index \> 0`
+    if test "$opal_scope_test" = "0"; then
+        AC_MSG_WARN([[OPAL_VAR_SCOPE_POP] popped too many OPAL configure scopes.])
+        AC_MSG_WARN([This usually indicates an error in configure.])
+        AC_MSG_ERROR([Cannot continue])
+    fi
+
+    # Get the variable names from that index
+    opal_str="opal_str=\"\$opal_scope_$opal_scope_index\""
+    eval $opal_str
+
+    # Iterate over all the variables and unset them all
+    for opal_var in $opal_str; do
+        unset $opal_var
+    done
+])dnl
+
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+#
+# OPAL_WITH_OPTION_MIN_MAX_VALUE(NAME,DEFAULT_VALUE,LOWER_BOUND,UPPER_BOUND)
+# Defines a variable OPAL_MAX_xxx, with "xxx" being specified as parameter $1 as "variable_name".
+# If not set at configure-time using --with-max-xxx, the default-value ($2) is assumed.
+# If set, value is checked against lower (value >= $3) and upper bound (value <= $4)
+#
+AC_DEFUN([OPAL_WITH_OPTION_MIN_MAX_VALUE], [
+    max_value=[$2]
+    AC_MSG_CHECKING([maximum length of ]m4_translit($1, [_], [ ]))
+    AC_ARG_WITH([max-]m4_translit($1, [_], [-]),
+        AC_HELP_STRING([--with-max-]m4_translit($1, [_], [-])[=VALUE],
+                       [maximum length of ]m4_translit($1, [_], [ ])[s.  VALUE argument has to be specified (default: [$2]).]))
+    if test ! -z "$with_max_[$1]" && test "$with_max_[$1]" != "no" ; then
+        # Ensure it's a number (hopefully an integer!), and >0
+        expr $with_max_[$1] + 1 > /dev/null 2> /dev/null
+        AS_IF([test "$?" != "0"], [happy=0],
+              [AS_IF([test $with_max_[$1] -ge $3 && test $with_max_[$1] -le $4],
+                     [happy=1], [happy=0])])
+
+        # If badness in the above tests, bail
+        AS_IF([test "$happy" = "0"],
+              [AC_MSG_RESULT([bad value ($with_max_[$1])])
+               AC_MSG_WARN([--with-max-]m4_translit($1, [_], [-])[s value must be >= $3 and <= $4])
+               AC_MSG_ERROR([Cannot continue])])
+        max_value=$with_max_[$1]
+    fi
+    AC_MSG_RESULT([$max_value])
+    AC_DEFINE_UNQUOTED([OPAL_MAX_]m4_toupper($1), $max_value,
+                       [Maximum length of ]m4_translit($1, [_], [ ])[s (default is $2)])
+    [OPAL_MAX_]m4_toupper($1)=$max_value
+    AC_SUBST([OPAL_MAX_]m4_toupper($1))
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# Usage: OPAL_COMPUTE_MAX_VALUE(number_bytes, variable_to_set, action if overflow)
+# Compute maximum value of datatype of
+# number_bytes, setting the result in the second argument.  Assumes a
+# signed datatype.
+AC_DEFUN([OPAL_COMPUTE_MAX_VALUE], [
+    # This is more complicated than it really should be.  But some
+    # expr implementations (OpenBSD) have an expr with a max value of
+    # 2^31 - 1, and we sometimes want to compute the max value of a
+    # type as big or bigger than that...
+    opal_num_bits=`expr $1 \* 8 - 1`
+    newval=1
+    value=1
+    overflow=0
+
+    while test $opal_num_bits -ne 0 ; do
+        newval=`expr $value \* 2`
+        if test 0 -eq `expr $newval \< 0` ; then
+            # if the new value is not negative, next iteration...
+            value=$newval
+            opal_num_bits=`expr $opal_num_bits - 1`
+            # if this was the last iteration, subtract 1 (as signed
+            # max positive is 2^num_bits - 1).  Do this here instead
+            # of outside of the while loop because we might have
+            # already subtracted 1 by then if we're trying to find the
+            # max value of the same datatype expr uses as it's
+            # internal representation (ie, if we hit the else
+            # below...)
+            if test 0 -eq $opal_num_bits ; then
+                value=`expr $value - 1`
+            fi
+        else
+            # if the new value is negative, we've over flowed.  First,
+            # try adding value - 1 instead of value (see if we can get
+            # to positive max of expr)
+            newval=`expr $value - 1 + $value`
+            if test 0 -eq `expr $newval \< 0` ; then
+                value=$newval
+                # Still positive, this is as high as we can go.  If
+                # opal_num_bits is 1, we didn't actually overflow.
+                # Otherwise, we overflowed.
+                if test 1 -ne $opal_num_bits ; then
+                    overflow=1
+                fi
+            else
+                # still negative.  Time to give up.
+                overflow=1
+            fi
+            opal_num_bits=0
+        fi
+    done
+
+    AS_VAR_SET([$2], [$value])
+    AS_IF([test $overflow -ne 0], [$3])
+])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,72 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2010 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
+#                         reserved.
+# Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2013      Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2018 Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2020      Lawrence Livermore National Security, LLC.
+#                         All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AC_INIT([pmi-shim],
+        [1.0],
+        [https://github.com/pmix/pmi-shim/issues],
+        [pmi-shim],
+        [https://github.com/pmix/pmi-shim],
+)
+AC_CONFIG_AUX_DIR(./config)
+# Note that this directory must *exactly* match what was specified via
+# -I in ACLOCAL_AMFLAGS in the top-level Makefile.am.
+AC_CONFIG_MACRO_DIR(./config)
+
+AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define tar-ustar -Wall -Werror])
+
+# SILENT_RULES is new in AM 1.11, but we require 1.11 or higher via
+# autogen.  Limited testing shows that calling SILENT_RULES directly
+# works in more cases than adding "silent-rules" to INIT_AUTOMAKE
+# (even though they're supposed to be identical).  Shrug.
+AM_SILENT_RULES([yes])
+
+# Set the language
+AC_LANG([C])
+
+# Find a C compiler
+AC_PROG_CC
+# Required for linking libraries according to automake warnings
+AM_PROG_AR
+
+LT_INIT([disable-static])
+
+AC_CONFIG_HEADERS([src/include/pmix_config.h])
+AC_CONFIG_FILES([Makefile src/Makefile test/Makefile])
+AC_CHECK_HEADERS([string.h unistd.h stdlib.h])
+
+OPAL_CONFIGURE_SETUP
+OPAL_CHECK_PMIX
+m4_ifdef([project_ompi], [OMPI_CONFIGURE_OPTIONS])
+
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,8 @@ AC_CHECK_HEADERS([string.h unistd.h stdlib.h])
 
 OPAL_CONFIGURE_SETUP
 OPAL_CHECK_PMIX
-m4_ifdef([project_ompi], [OMPI_CONFIGURE_OPTIONS])
+if test "$opal_external_pmix_happy" = "no"; then
+   AC_MSG_ERROR([could not find PMIx])
+fi
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,0 +1,7 @@
+AM_CPPFLAGS = \
+	-I$(top_builddir)
+
+lib_LTLIBRARIES = libpmi.la
+libpmi_la_SOURCES = pmi1.c pmi.h
+libpmi_la_LDFLAGS = -version-info 0:0:0
+include_HEADERS = pmi.h

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -1,0 +1,2 @@
+#define pmix_output_verbose(...) 
+

--- a/src/pmi.h
+++ b/src/pmi.h
@@ -1,0 +1,832 @@
+/*****************************************************************************\
+ *  pmi.h - Process Management Interface for MPICH2
+ *  See http://www-unix.mcs.anl.gov/mpi/mpich2/
+ *
+ *  NOTE: Dynamic Process Management functions (PMI part 2) are not supported
+ *  at this time. Functions required for MPI-1 (PMI part 1) are supported.
+ *****************************************************************************
+ *  COPYRIGHT
+ *
+ *  The following is a notice of limited availability of the code, and
+ *  disclaimer which must be included in the prologue of the code and in all
+ *  source listings of the code.
+ *
+ *  Copyright Notice + 2002 University of Chicago
+ *
+ *  Permission is hereby granted to use, reproduce, prepare derivative
+ *  works, and to redistribute to others. This software was authored by:
+ *
+ *  Argonne National Laboratory Group
+ *  W. Gropp: (630) 252-4318; FAX: (630) 252-5986; e-mail: gropp@mcs.anl.gov
+ *  E. Lusk: (630) 252-7852; FAX: (630) 252-5986; e-mail: lusk@mcs.anl.gov
+ *  Mathematics and Computer Science Division Argonne National Laboratory,
+ *  Argonne IL 60439
+ *
+ *  GOVERNMENT LICENSE
+ *
+ *  Portions of this material resulted from work developed under a U.S.
+ *  Government Contract and are subject to the following license: the
+ *  Government is granted for itself and others acting on its behalf a
+ *  paid-up, nonexclusive, irrevocable worldwide license in this computer
+ *  software to reproduce, prepare derivative works, and perform publicly
+ *  and display publicly.
+ *
+ *  DISCLAIMER
+ *
+ *  This computer code material was prepared, in part, as an account of work
+ *  sponsored by an agency of the United States Government. Neither the
+ *  United States, nor the University of Chicago, nor any of their
+ *  employees, makes any warranty express or implied, or assumes any legal
+ *  liability or responsibility for the accuracy, completeness, or
+ *  usefulness of any information, apparatus, product, or process disclosed,
+ *  or represents that its use would not infringe privately owned rights.
+ *
+ *  MCS Division <http://www.mcs.anl.gov>        Argonne National Laboratory
+ *  <http://www.anl.gov>     University of Chicago <http://www.uchicago.edu>
+\*****************************************************************************/
+
+#ifndef PMI_H
+#define PMI_H
+
+/* Structure and constant definitions */
+#include <pmix_common.h>
+
+/* prototypes for the PMI interface in MPICH2 */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*D
+PMI_CONSTANTS - PMI definitions
+
+Error Codes:
++ PMI_SUCCESS - operation completed successfully
+. PMI_FAIL - operation failed
+. PMI_ERR_NOMEM - input buffer not large enough
+. PMI_ERR_INIT - PMI not initialized
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_KEY_LENGTH - invalid key length argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_VAL_LENGTH - invalid val length argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+. PMI_ERR_INVALID_NUM_ARGS - invalid number of arguments
+. PMI_ERR_INVALID_ARGS - invalid args argument
+. PMI_ERR_INVALID_NUM_PARSED - invalid num_parsed length argument
+. PMI_ERR_INVALID_KEYVALP - invalid keyvalp argument
+- PMI_ERR_INVALID_SIZE - invalid size argument
+
+Booleans:
++ PMI_TRUE - true
+- PMI_FALSE - false
+
+D*/
+#define PMI_SUCCESS                  0
+#define PMI_FAIL                    -1
+#define PMI_ERR_INIT                 1
+#define PMI_ERR_NOMEM                2
+#define PMI_ERR_INVALID_ARG          3
+#define PMI_ERR_INVALID_KEY          4
+#define PMI_ERR_INVALID_KEY_LENGTH   5
+#define PMI_ERR_INVALID_VAL          6
+#define PMI_ERR_INVALID_VAL_LENGTH   7
+#define PMI_ERR_INVALID_LENGTH       8
+#define PMI_ERR_INVALID_NUM_ARGS     9
+#define PMI_ERR_INVALID_ARGS        10
+#define PMI_ERR_INVALID_NUM_PARSED  11
+#define PMI_ERR_INVALID_KEYVALP     12
+#define PMI_ERR_INVALID_SIZE        13
+#define PMI_ERR_INVALID_KVS         14
+
+typedef int PMI_BOOL;
+#define PMI_TRUE     1
+#define PMI_FALSE    0
+
+/* PMI Group functions */
+
+/*@
+PMI_Init - initialize the Process Manager Interface
+
+Output Parameter:
+. spawned - spawned flag
+
+Return values:
++ PMI_SUCCESS - initialization completed successfully
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - initialization failed
+
+Notes:
+Initialize PMI for this process group. The value of spawned indicates whether
+this process was created by 'PMI_Spawn_multiple'.  'spawned' will be 'PMI_TRUE' if
+this process group has a parent and 'PMI_FALSE' if it does not.
+
+@*/
+PMIX_EXPORT int PMI_Init( int *spawned );
+
+/*@
+PMI_Initialized - check if PMI has been initialized
+
+Output Parameter:
+. initialized - boolean value
+
+Return values:
++ PMI_SUCCESS - initialized successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the variable
+
+Notes:
+On successful output, initialized will either be 'PMI_TRUE' or 'PMI_FALSE'.
+
++ PMI_TRUE - initialize has been called.
+- PMI_FALSE - initialize has not been called or previously failed.
+
+@*/
+PMIX_EXPORT int PMI_Initialized( PMI_BOOL *initialized );
+
+/*@
+PMI_Finalize - finalize the Process Manager Interface
+
+Return values:
++ PMI_SUCCESS - finalization completed successfully
+- PMI_FAIL - finalization failed
+
+Notes:
+ Finalize PMI for this process group.
+
+@*/
+PMIX_EXPORT int PMI_Finalize( void );
+
+/*@
+PMI_Get_size - obtain the size of the process group
+
+Output Parameters:
+. size - pointer to an integer that receives the size of the process group
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+Notes:
+This function returns the size of the process group to which the local process
+belongs.
+
+@*/
+PMIX_EXPORT int PMI_Get_size( int *size );
+
+/*@
+PMI_Get_rank - obtain the rank of the local process in the process group
+
+Output Parameters:
+. rank - pointer to an integer that receives the rank in the process group
+
+Return values:
++ PMI_SUCCESS - rank successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the rank
+
+Notes:
+This function returns the rank of the local process in its process group.
+
+@*/
+PMIX_EXPORT int PMI_Get_rank( int *rank );
+
+/*@
+PMI_Get_universe_size - obtain the universe size
+
+Output Parameters:
+. size - pointer to an integer that receives the size
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+
+@*/
+PMIX_EXPORT int PMI_Get_universe_size( int *size );
+
+/*@
+PMI_Get_appnum - obtain the application number
+
+Output parameters:
+. appnum - pointer to an integer that receives the appnum
+
+Return values:
++ PMI_SUCCESS - appnum successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the size
+
+
+@*/
+PMIX_EXPORT int PMI_Get_appnum( int *appnum );
+
+/*@
+PMI_Publish_name - publish a name
+
+Input parameters:
+. service_name - string representing the service being published
+. port - string representing the port on which to contact the service
+
+Return values:
++ PMI_SUCCESS - port for service successfully published
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to publish service
+
+
+@*/
+PMIX_EXPORT int PMI_Publish_name( const char service_name[], const char port[] );
+
+/*@
+PMI_Unpublish_name - unpublish a name
+
+Input parameters:
+. service_name - string representing the service being unpublished
+
+Return values:
++ PMI_SUCCESS - port for service successfully published
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to unpublish service
+
+
+@*/
+PMIX_EXPORT int PMI_Unpublish_name( const char service_name[] );
+
+/*@
+PMI_Lookup_name - lookup a service by name
+
+Input parameters:
+. service_name - string representing the service being published
+
+Output parameters:
+. port - string representing the port on which to contact the service
+
+Return values:
++ PMI_SUCCESS - port for service successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to lookup service
+
+
+@*/
+PMIX_EXPORT int PMI_Lookup_name( const char service_name[], char port[] );
+
+/*@
+PMI_Get_id - obtain the id of the process group
+
+Input Parameter:
+. length - length of the id_str character array
+
+Output Parameter:
+. id_str - character array that receives the id of the process group
+
+Return values:
++ PMI_SUCCESS - id successfully obtained
+. PMI_ERR_INVALID_ARG - invalid rank argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to return the id
+
+Notes:
+This function returns a string that uniquely identifies the process group
+that the local process belongs to.  The string passed in must be at least
+as long as the number returned by 'PMI_Get_id_length_max()'.
+
+@*/
+PMIX_EXPORT int PMI_Get_id( char id_str[], int length );
+
+/*@
+PMI_Get_kvs_domain_id - obtain the id of the PMI domain
+
+Input Parameter:
+. length - length of id_str character array
+
+Output Parameter:
+. id_str - character array that receives the id of the PMI domain
+
+Return values:
++ PMI_SUCCESS - id successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to return the id
+
+Notes:
+This function returns a string that uniquely identifies the PMI domain
+where keyval spaces can be shared.  The string passed in must be at least
+as long as the number returned by 'PMI_Get_id_length_max()'.
+
+@*/
+PMIX_EXPORT int PMI_Get_kvs_domain_id( char id_str[], int length );
+
+/*@
+PMI_Get_id_length_max - obtain the maximum length of an id string
+
+Output Parameters:
+. length - the maximum length of an id string
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the maximum length
+
+Notes:
+This function returns the maximum length of a process group id string.
+
+@*/
+PMIX_EXPORT int PMI_Get_id_length_max( int *length );
+
+/*@
+PMI_Barrier - barrier across the process group
+
+Return values:
++ PMI_SUCCESS - barrier successfully finished
+- PMI_FAIL - barrier failed
+
+Notes:
+This function is a collective call across all processes in the process group
+the local process belongs to.  It will not return until all the processes
+have called 'PMI_Barrier()'.
+
+@*/
+PMIX_EXPORT int PMI_Barrier( void );
+
+/*@
+PMI_Get_clique_size - obtain the number of processes on the local node
+
+Output Parameters:
+. size - pointer to an integer that receives the size of the clique
+
+Return values:
++ PMI_SUCCESS - size successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to return the clique size
+
+Notes:
+This function returns the number of processes in the local process group that
+are on the local node along with the local process.  This is a simple topology
+function to distinguish between processes that can communicate through IPC
+mechanisms (e.g., shared memory) and other network mechanisms.
+
+@*/
+PMIX_EXPORT int PMI_Get_clique_size( int *size );
+
+/*@
+PMI_Get_clique_ranks - get the ranks of the local processes in the process group
+
+Input Parameters:
+. length - length of the ranks array
+
+Output Parameters:
+. ranks - pointer to an array of integers that receive the local ranks
+
+Return values:
++ PMI_SUCCESS - ranks successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to return the ranks
+
+Notes:
+This function returns the ranks of the processes on the local node.  The array
+must be at least as large as the size returned by 'PMI_Get_clique_size()'.  This
+is a simple topology function to distinguish between processes that can
+communicate through IPC mechanisms (e.g., shared memory) and other network
+mechanisms.
+
+@*/
+PMIX_EXPORT int PMI_Get_clique_ranks( int ranks[], int length);
+
+/*@
+PMI_Abort - abort the process group associated with this process
+
+Input Parameters:
++ exit_code - exit code to be returned by this process
+- error_msg - error message to be printed
+
+Return values:
+. none - this function should not return
+@*/
+PMIX_EXPORT int PMI_Abort(int exit_code, const char error_msg[]);
+
+/* PMI Keymap functions */
+/*@
+PMI_KVS_Get_my_name - obtain the name of the keyval space the local process group has access to
+
+Input Parameters:
+. length - length of the kvsname character array
+
+Output Parameters:
+. kvsname - a string that receives the keyval space name
+
+Return values:
++ PMI_SUCCESS - kvsname successfully obtained
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to return the kvsname
+
+Notes:
+This function returns the name of the keyval space that this process and all
+other processes in the process group have access to.  The output parameter,
+kvsname, must be at least as long as the value returned by
+'PMI_KVS_Get_name_length_max()'.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Get_my_name( char kvsname[], int length );
+
+/*@
+PMI_KVS_Get_name_length_max - obtain the length necessary to store a kvsname
+
+Output Parameter:
+. length - maximum length required to hold a keyval space name
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a keyval space name.
+
+A routine is used rather than setting a maximum value in 'pmi.h' to allow
+different implementations of PMI to be used with the same executable.  These
+different implementations may allow different maximum lengths; by using a
+routine here, we can interface with a variety of implementations of PMI.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Get_name_length_max( int *length );
+
+/*@
+PMI_KVS_Get_key_length_max - obtain the length necessary to store a key
+
+Output Parameter:
+. length - maximum length required to hold a key string.
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a key.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Get_key_length_max( int *length );
+
+/*@
+PMI_KVS_Get_value_length_max - obtain the length necessary to store a value
+
+Output Parameter:
+. length - maximum length required to hold a keyval space value
+
+Return values:
++ PMI_SUCCESS - length successfully set
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to set the length
+
+Notes:
+This function returns the string length required to store a value from a
+keyval space.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Get_value_length_max( int *length );
+
+/*@
+PMI_KVS_Create - create a new keyval space
+
+Input Parameter:
+. length - length of the kvsname character array
+
+Output Parameters:
+. kvsname - a string that receives the keyval space name
+
+Return values:
++ PMI_SUCCESS - keyval space successfully created
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - unable to create a new keyval space
+
+Notes:
+This function creates a new keyval space.  Everyone in the same process group
+can access this keyval space by the name returned by this function.  The
+function is not collective.  Only one process calls this function.  The output
+parameter, kvsname, must be at least as long as the value returned by
+'PMI_KVS_Get_name_length_max()'.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Create( char kvsname[], int length );
+
+/*@
+PMI_KVS_Destroy - destroy keyval space
+
+Input Parameters:
+. kvsname - keyval space name
+
+Return values:
++ PMI_SUCCESS - keyval space successfully destroyed
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - unable to destroy the keyval space
+
+Notes:
+This function destroys a keyval space created by 'PMI_KVS_Create()'.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Destroy( const char kvsname[] );
+
+/*@
+PMI_KVS_Put - put a key/value pair in a keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key - key
+- value - value
+
+Return values:
++ PMI_SUCCESS - keyval pair successfully put in keyval space
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+- PMI_FAIL - put failed
+
+Notes:
+This function puts the key/value pair in the specified keyval space.  The
+value is not visible to other processes until 'PMI_KVS_Commit()' is called.
+The function may complete locally.  After 'PMI_KVS_Commit()' is called, the
+value may be retrieved by calling 'PMI_KVS_Get()'.  All keys put to a keyval
+space must be unique to the keyval space.  You may not put more than once
+with the same key.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Put( const char kvsname[], const char key[], const char value[]);
+
+/*@
+PMI_KVS_Commit - commit all previous puts to the keyval space
+
+Input Parameters:
+. kvsname - keyval space name
+
+Return values:
++ PMI_SUCCESS - commit succeeded
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - commit failed
+
+Notes:
+This function commits all previous puts since the last 'PMI_KVS_Commit()' into
+the specified keyval space. It is a process local operation.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Commit( const char kvsname[] );
+
+/*@
+PMI_KVS_Get - get a key/value pair from a keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key - key
+- length - length of value character array
+
+Output Parameters:
+. value - value
+
+Return values:
++ PMI_SUCCESS - get succeeded
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+- PMI_FAIL - get failed
+
+Notes:
+This function gets the value of the specified key in the keyval space.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length);
+
+/*@
+PMI_KVS_Iter_first - initialize the iterator and get the first value
+
+Input Parameters:
++ kvsname - keyval space name
+. key_len - length of key character array
+- val_len - length of val character array
+
+Output Parameters:
++ key - key
+- value - value
+
+Return values:
++ PMI_SUCCESS - keyval pair successfully retrieved from the keyval space
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_KEY_LENGTH - invalid key length argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_VAL_LENGTH - invalid val length argument
+- PMI_FAIL - failed to initialize the iterator and get the first keyval pair
+
+Notes:
+This function initializes the iterator for the specified keyval space and
+retrieves the first key/val pair.  The end of the keyval space is specified
+by returning an empty key string.  key and val must be at least as long as
+the values returned by 'PMI_KVS_Get_key_length_max()' and
+'PMI_KVS_Get_value_length_max()'.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len);
+
+/*@
+PMI_KVS_Iter_next - get the next keyval pair from the keyval space
+
+Input Parameters:
++ kvsname - keyval space name
+. key_len - length of key character array
+- val_len - length of val character array
+
+Output Parameters:
++ key - key
+- value - value
+
+Return values:
++ PMI_SUCCESS - keyval pair successfully retrieved from the keyval space
+. PMI_ERR_INVALID_KVS - invalid kvsname argument
+. PMI_ERR_INVALID_KEY - invalid key argument
+. PMI_ERR_INVALID_KEY_LENGTH - invalid key length argument
+. PMI_ERR_INVALID_VAL - invalid val argument
+. PMI_ERR_INVALID_VAL_LENGTH - invalid val length argument
+- PMI_FAIL - failed to get the next keyval pair
+
+Notes:
+This function retrieves the next keyval pair from the specified keyval space.
+'PMI_KVS_Iter_first()' must have been previously called.  The end of the keyval
+space is specified by returning an empty key string.  The output parameters,
+key and val, must be at least as long as the values returned by
+'PMI_KVS_Get_key_length_max()' and 'PMI_KVS_Get_value_length_max()'.
+
+@*/
+PMIX_EXPORT int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len);
+
+/* PMI Process Creation functions */
+
+/*S
+PMI_keyval_t - keyval structure used by PMI_Spawn_mulitiple
+
+Fields:
++ key - name of the key
+- val - value of the key
+
+S*/
+typedef struct PMI_keyval_t
+{
+    char * key;
+    char * val;
+} PMI_keyval_t;
+
+/*@
+PMI_Spawn_multiple - spawn a new set of processes
+
+Input Parameters:
++ count - count of commands
+. cmds - array of command strings
+. argvs - array of argv arrays for each command string
+. maxprocs - array of maximum processes to spawn for each command string
+. info_keyval_sizes - array giving the number of elements in each of the
+  'info_keyval_vectors'
+. info_keyval_vectors - array of keyval vector arrays
+. preput_keyval_size - Number of elements in 'preput_keyval_vector'
+- preput_keyval_vector - array of keyvals to be pre-put in the spawned keyval space
+
+Output Parameter:
+. errors - array of errors for each command
+
+Return values:
++ PMI_SUCCESS - spawn successful
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - spawn failed
+
+Notes:
+This function spawns a set of processes into a new process group.  The 'count'
+field refers to the size of the array parameters - 'cmd', 'argvs', 'maxprocs',
+'info_keyval_sizes' and 'info_keyval_vectors'.  The 'preput_keyval_size' refers
+to the size of the 'preput_keyval_vector' array.  The 'preput_keyval_vector'
+contains keyval pairs that will be put in the keyval space of the newly
+created process group before the processes are started.  The 'maxprocs' array
+specifies the desired number of processes to create for each 'cmd' string.
+The actual number of processes may be less than the numbers specified in
+maxprocs.  The acceptable number of processes spawned may be controlled by
+``soft'' keyvals in the info arrays.  The ``soft'' option is specified by
+mpiexec in the MPI-2 standard.  Environment variables may be passed to the
+spawned processes through PMI implementation specific 'info_keyval' parameters.
+@*/
+PMIX_EXPORT int PMI_Spawn_multiple(int count,
+                                   const char * cmds[],
+                                   const char ** argvs[],
+                                   const int maxprocs[],
+                                   const int info_keyval_sizesp[],
+                                   const PMI_keyval_t * info_keyval_vectors[],
+                                   int preput_keyval_size,
+                                   const PMI_keyval_t preput_keyval_vector[],
+                                   int errors[]);
+
+
+/*@
+PMI_Parse_option - create keyval structures from a single command line argument
+
+Input Parameters:
++ num_args - length of args array
+- args - array of command line arguments starting with the argument to be parsed
+
+Output Parameters:
++ num_parsed - number of elements of the argument array parsed
+. keyvalp - pointer to an array of keyvals
+- size - size of the allocated array
+
+Return values:
++ PMI_SUCCESS - success
+. PMI_ERR_INVALID_NUM_ARGS - invalid number of arguments
+. PMI_ERR_INVALID_ARGS - invalid args argument
+. PMI_ERR_INVALID_NUM_PARSED - invalid num_parsed length argument
+. PMI_ERR_INVALID_KEYVALP - invalid keyvalp argument
+. PMI_ERR_INVALID_SIZE - invalid size argument
+- PMI_FAIL - fail
+
+Notes:
+This function removes one PMI specific argument from the command line and
+creates the corresponding 'PMI_keyval_t' structure for it.  It returns
+an array and size to the caller.  The array must be freed by 'PMI_Free_keyvals()'.
+If the first element of the args array is not a PMI specific argument, the function
+returns success and sets num_parsed to zero.  If there are multiple PMI specific
+arguments in the args array, this function may parse more than one argument as long
+as the options are contiguous in the args array.
+
+@*/
+PMIX_EXPORT int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size);
+
+/*@
+PMI_Args_to_keyval - create keyval structures from command line arguments
+
+Input Parameters:
++ argcp - pointer to argc
+- argvp - pointer to argv
+
+Output Parameters:
++ keyvalp - pointer to an array of keyvals
+- size - size of the allocated array
+
+Return values:
++ PMI_SUCCESS - success
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - fail
+
+Notes:
+This function removes PMI specific arguments from the command line and
+creates the corresponding 'PMI_keyval_t' structures for them.  It returns
+an array and size to the caller that can then be passed to 'PMI_Spawn_multiple()'.
+The array can be freed by 'PMI_Free_keyvals()'.  The routine 'free()' should
+not be used to free this array as there is no requirement that the array be
+allocated with 'malloc()'.
+
+@*/
+PMIX_EXPORT int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size);
+
+/*@
+PMI_Free_keyvals - free the keyval structures created by PMI_Args_to_keyval
+
+Input Parameters:
++ keyvalp - array of keyvals
+- size - size of the array
+
+Return values:
++ PMI_SUCCESS - success
+. PMI_ERR_INVALID_ARG - invalid argument
+- PMI_FAIL - fail
+
+Notes:
+ This function frees the data returned by 'PMI_Args_to_keyval' and 'PMI_Parse_option'.
+ Using this routine instead of 'free' allows the PMI package to track
+ allocation of storage or to use interal storage as it sees fit.
+@*/
+PMIX_EXPORT int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size);
+
+/*@
+PMI_Get_options - get a string of command line argument descriptions that may be printed to the user
+
+Input Parameters:
+. length - length of str
+
+Output Parameters:
++ str - description string
+- length - length of string or necessary length if input is not large enough
+
+Return values:
++ PMI_SUCCESS - success
+. PMI_ERR_INVALID_ARG - invalid argument
+. PMI_ERR_INVALID_LENGTH - invalid length argument
+. PMI_ERR_NOMEM - input length too small
+- PMI_FAIL - fail
+
+Notes:
+ This function returns the command line options specific to the pmi implementation
+@*/
+PMIX_EXPORT int PMI_Get_options(char *str, int *length);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/src/pmi1.c
+++ b/src/pmi1.c
@@ -1,0 +1,928 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <pmix.h>
+#include <pmi.h>
+
+#include "src/include/pmix_globals.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#include PMIX_EVENT_HEADER
+
+#define ANL_MAPPING "PMI_process_mapping"
+
+#include "src/mca/bfrops/bfrops.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+
+#define PMI_MAX_ID_LEN       PMIX_MAX_NSLEN  /* Maximim size of PMI process group ID */
+#define PMI_MAX_KEY_LEN      PMIX_MAX_KEYLEN /* Maximum size of a PMI key */
+#define PMI_MAX_KVSNAME_LEN  PMIX_MAX_NSLEN  /* Maximum size of KVS name */
+#define PMI_MAX_VAL_LEN      4096            /* Maximum size of a PMI value */
+
+
+#define PMI_CHECK()             \
+    do {                        \
+        if (!pmi_init) {        \
+            return PMI_FAIL;    \
+        }                       \
+    } while (0)
+
+/* local functions */
+static pmix_status_t convert_int(int *value, pmix_value_t *kv);
+static int convert_err(pmix_status_t rc);
+static pmix_proc_t myproc;
+static int pmi_init = 0;
+static bool pmi_singleton = false;
+
+PMIX_EXPORT int PMI_Init(int *spawned)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+    pmix_info_t info[1];
+    bool  val_optinal = 1;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        /* if we didn't see a PMIx server (e.g., missing envar),
+         * then allow us to run as a singleton */
+        if (PMIX_ERR_INVALID_NAMESPACE == rc) {
+            if (NULL != spawned) {
+                *spawned = 0;
+            }
+            pmi_singleton = true;
+            pmix_strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
+            myproc.rank = 0;
+            pmi_init = 1;
+            return PMI_SUCCESS;
+        }
+        return PMI_ERR_INIT;
+    }
+
+    /* getting internal key requires special rank value */
+    memcpy(&proc, &myproc, sizeof(myproc));
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT(&info[0]);
+    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
+
+    if (NULL != spawned) {
+        /* get the spawned flag */
+        if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_SPAWNED, info, 1, &val)) {
+            rc = convert_int(spawned, val);
+            PMIX_VALUE_RELEASE(val);
+            if (PMIX_SUCCESS != rc) {
+                goto error;
+            }
+        } else {
+            /* if not found, default to not spawned */
+            *spawned = 0;
+        }
+    }
+    pmi_init = 1;
+
+    rc = PMIX_SUCCESS;
+
+error:
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Initialized(PMI_BOOL *initialized)
+{
+    if (NULL == initialized) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *initialized = PMI_TRUE;
+    } else {
+        *initialized = (PMIx_Initialized() ? PMI_TRUE : PMI_FALSE);
+    }
+
+    return PMI_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_Finalize(void)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    PMI_CHECK();
+
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
+    pmi_init = 0;
+    rc = PMIx_Finalize(NULL, 0);
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Abort(int flag, const char msg[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    PMI_CHECK();
+
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
+    rc = PMIx_Abort(flag, msg, NULL, 0);
+    return convert_err(rc);
+}
+
+/* KVS_Put - we default to PMIX_GLOBAL scope and ignore the
+ * provided kvsname as we only put into our own nspace */
+PMIX_EXPORT int PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t val;
+
+    PMI_CHECK();
+
+    if ((kvsname == NULL) || (strlen(kvsname) > PMI_MAX_KVSNAME_LEN)) {
+        return PMI_ERR_INVALID_KVS;
+    }
+    if ((key == NULL) || (strlen(key) >PMI_MAX_KEY_LEN)) {
+        return PMI_ERR_INVALID_KEY;
+    }
+    if ((value == NULL) || (strlen(value) > PMI_MAX_VAL_LEN)) {
+        return PMI_ERR_INVALID_VAL;
+    }
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+            "PMI_KVS_Put: KVS=%s, key=%s value=%s", kvsname, key, value);
+
+    val.type = PMIX_STRING;
+    val.data.string = (char*)value;
+    rc = PMIx_Put(PMIX_GLOBAL, key, &val);
+    return convert_err(rc);
+}
+
+/* KVS_Commit */
+PMIX_EXPORT int PMI_KVS_Commit(const char kvsname[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    PMI_CHECK();
+
+    if ((kvsname == NULL) || (strlen(kvsname) > PMI_MAX_KVSNAME_LEN)) {
+        return PMI_ERR_INVALID_KVS;
+    }
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
+    pmix_output_verbose(2, pmix_globals.debug_output, "PMI_KVS_Commit: KVS=%s",
+            kvsname);
+
+    rc = PMIx_Commit();
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+
+    PMI_CHECK();
+
+    if ((kvsname == NULL) || (strlen(kvsname) > PMI_MAX_KVSNAME_LEN)) {
+        return PMI_ERR_INVALID_KVS;
+    }
+    if ((key == NULL) || (strlen(key) > PMI_MAX_KEY_LEN)) {
+        return PMI_ERR_INVALID_KEY;
+    }
+    if (value == NULL) {
+        return PMI_ERR_INVALID_VAL;
+    }
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+            "PMI_KVS_Get: KVS=%s, key=%s value=%s", kvsname, key, value);
+
+    /* PMI-1 expects resource manager to set
+     * process mapping in ANL notation. */
+    if (!strcmp(key, ANL_MAPPING)) {
+        /* we are looking in the job-data. If there is nothing there
+         * we don't want to look in rank's data, thus set rank to widcard */
+        proc = myproc;
+        proc.rank = PMIX_RANK_WILDCARD;
+        if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_ANL_MAP, NULL, 0, &val) &&
+               (NULL != val) && (PMIX_STRING == val->type)) {
+            pmix_strncpy(value, val->data.string, length-1);
+            PMIX_VALUE_FREE(val, 1);
+            return PMI_SUCCESS;
+        } else {
+            /* artpol:
+             * Some RM's (i.e. SLURM) already have ANL precomputed. The export it
+             * through PMIX_ANL_MAP variable.
+             * If we haven't found it we want to have our own packing functionality
+             * since it's common.
+             * Somebody else has to write it since I've already done that for
+             * GPL'ed SLURM :) */
+            return PMI_FAIL;
+        }
+    }
+
+    /* retrieve the data from PMIx - since we don't have a rank,
+     * we indicate that by passing the UNDEF value */
+    pmix_strncpy(proc.nspace, kvsname, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_UNDEF;
+
+    rc = PMIx_Get(&proc, key, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc && NULL != val) {
+        if (PMIX_STRING != val->type) {
+            rc = PMIX_ERROR;
+        } else if (NULL != val->data.string) {
+            pmix_strncpy(value, val->data.string, length-1);
+        }
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    return convert_err(rc);
+}
+
+/* Barrier only applies to our own nspace, and we want all
+ * data to be collected upon completion */
+PMIX_EXPORT int PMI_Barrier(void)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_info_t buf;
+    int ninfo = 0;
+    pmix_info_t *info = NULL;
+    bool val = 1;
+
+    PMI_CHECK();
+
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
+    info = &buf;
+    PMIX_INFO_CONSTRUCT(info);
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &val, PMIX_BOOL);
+    ninfo = 1;
+    rc = PMIx_Fence(NULL, 0, info, ninfo);
+
+    PMIX_INFO_DESTRUCT(info);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Get_size(int *size)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optinal = 1;
+    pmix_proc_t proc = myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    PMI_CHECK();
+
+    if (NULL == size) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *size = 1;
+        return PMI_SUCCESS;
+    }
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT(&info[0]);
+    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
+
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
+        rc = convert_int(size, val);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Get_rank(int *rk)
+{
+    PMI_CHECK();
+
+    if (NULL == rk) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    *rk = myproc.rank;
+    return PMI_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_Get_universe_size(int *size)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optinal = 1;
+    pmix_proc_t proc = myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    PMI_CHECK();
+
+    if (NULL == size) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *size = 1;
+        return PMI_SUCCESS;
+    }
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT(&info[0]);
+    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
+
+    rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
+        rc = convert_int(size, val);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Get_appnum(int *appnum)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optinal = 1;
+
+    PMI_CHECK();
+
+    if (NULL == appnum) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *appnum = 0;
+        return PMI_SUCCESS;
+    }
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT(&info[0]);
+    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
+
+    rc = PMIx_Get(&myproc, PMIX_APPNUM, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
+        rc = convert_int(appnum, val);
+        PMIX_VALUE_RELEASE(val);
+    } else {
+        /* this is optional value, set to 0 */
+        *appnum = 0;
+        rc = PMIX_SUCCESS;
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Publish_name(const char service_name[], const char port[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_info_t info;
+
+    PMI_CHECK();
+
+    if (NULL == service_name || NULL == port) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        return PMI_FAIL;
+    }
+
+    /* pass the service/port */
+    pmix_strncpy(info.key, service_name, PMIX_MAX_KEYLEN);
+    info.value.type = PMIX_STRING;
+    info.value.data.string = (char*) port;
+
+    /* publish the info - PMI-1 doesn't support
+     * any scope other than inside our own nspace */
+    rc = PMIx_Publish(&info, 1);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Unpublish_name(const char service_name[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    char *keys[2];
+
+    PMI_CHECK();
+
+    if (NULL == service_name) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        return PMI_FAIL;
+    }
+
+    /* pass the service */
+    keys[0] = (char*) service_name;
+    keys[1] = NULL;
+
+    rc = PMIx_Unpublish(keys, NULL, 0);
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_pdata_t pdata;
+
+    PMI_CHECK();
+
+    if (NULL == service_name || NULL == port) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        return PMI_FAIL;
+    }
+
+    PMIX_PDATA_CONSTRUCT(&pdata);
+
+    /* pass the service */
+    pmix_strncpy(pdata.key, service_name, PMIX_MAX_KEYLEN);
+
+    /* PMI-1 doesn't want the nspace back */
+    if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, NULL, 0))) {
+        return convert_err(rc);
+    }
+
+    /* should have received a string back */
+    if (PMIX_STRING != pdata.value.type || NULL == pdata.value.data.string) {
+        return convert_err(PMIX_ERR_NOT_FOUND);
+    }
+
+    /* return the port - sadly, this API doesn't tell us
+     * the size of the port array, and so there is a
+     * potential we could overrun it. As this feature
+     * isn't widely supported in PMI-1, try being
+     * conservative */
+    pmix_strncpy(port, pdata.value.data.string, PMIX_MAX_KEYLEN);
+    PMIX_PDATA_DESTRUCT(&pdata);
+
+    return PMIX_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_Get_id(char id_str[], int length)
+{
+    /* we already obtained our nspace during PMI_Init,
+     * so all we have to do here is return it */
+
+    PMI_CHECK();
+
+    /* bozo check */
+    if (NULL == id_str) {
+        return PMI_ERR_INVALID_ARGS;
+    }
+    if (length < PMI_MAX_ID_LEN) {
+        return PMI_ERR_INVALID_LENGTH;
+    }
+
+    pmix_strncpy(id_str, myproc.nspace, length-1);
+    return PMI_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_Get_kvs_domain_id(char id_str[], int length)
+{
+    PMI_CHECK();
+
+    /* same as PMI_Get_id */
+    return PMI_Get_id(id_str, length);
+}
+
+PMIX_EXPORT int PMI_Get_id_length_max(int *length)
+{
+    PMI_CHECK();
+
+    if (NULL == length) {
+        return PMI_ERR_INVALID_VAL_LENGTH;
+    }
+
+    *length = PMI_MAX_ID_LEN;
+    return PMI_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_Get_clique_size(int *size)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optinal = 1;
+    pmix_proc_t proc = myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    PMI_CHECK();
+
+    if (NULL == size) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *size = 1;
+        return PMI_SUCCESS;
+    }
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT(&info[0]);
+    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
+
+    rc = PMIx_Get(&proc, PMIX_LOCAL_SIZE, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
+        rc = convert_int(size, val);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_Get_clique_ranks(int ranks[], int length)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_value_t *val;
+    char **rks;
+    int i;
+    pmix_proc_t proc = myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    PMI_CHECK();
+
+    if (NULL == ranks) {
+        return PMI_ERR_INVALID_ARGS;
+    }
+
+    if (pmi_singleton) {
+        ranks[0] = 0;
+        return PMI_SUCCESS;
+    }
+
+    rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc) {
+        /* kv will contain a string of comma-separated
+         * ranks on my node */
+        rks = pmix_argv_split(val->data.string, ',');
+        for (i = 0; NULL != rks[i] && i < length; i++) {
+            ranks[i] = strtol(rks[i], NULL, 10);
+        }
+        pmix_argv_free(rks);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    return convert_err(rc);
+}
+
+PMIX_EXPORT int PMI_KVS_Get_my_name(char kvsname[], int length)
+{
+    PMI_CHECK();
+
+    /* same as PMI_Get_id */
+    return PMI_Get_id(kvsname, length);
+}
+
+PMIX_EXPORT int PMI_KVS_Get_name_length_max(int *length)
+{
+    PMI_CHECK();
+
+    if (NULL == length) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    *length = PMI_MAX_KVSNAME_LEN;
+    return PMI_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_KVS_Get_key_length_max(int *length)
+{
+    PMI_CHECK();
+
+    if (NULL == length) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    *length = PMI_MAX_KEY_LEN;
+    return PMI_SUCCESS;
+}
+
+PMIX_EXPORT int PMI_KVS_Get_value_length_max(int *length)
+{
+    PMI_CHECK();
+
+    if (NULL == length) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    /* don't give them an enormous size of some implementations
+     * immediately malloc a data block for their use */
+    *length = PMI_MAX_VAL_LEN;
+    return PMI_SUCCESS;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_KVS_Create(char kvsname[], int length)
+{
+    return PMI_FAIL;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_KVS_Destroy(const char kvsname[])
+{
+    return PMI_FAIL;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len)
+{
+    return PMI_FAIL;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len)
+{
+    return PMI_FAIL;
+}
+
+PMIX_EXPORT int PMI_Spawn_multiple(int count,
+                       const char * cmds[],
+                       const char ** argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizesp[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[],
+                       int errors[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_app_t *apps;
+    int i, k;
+    size_t j;
+    char *evar;
+
+    PMI_CHECK();
+
+    if (NULL == cmds) {
+        return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        return PMI_FAIL;
+    }
+
+    /* setup the apps */
+    PMIX_APP_CREATE(apps, count);
+    for (i = 0; i < count; i++) {
+        apps[i].cmd = strdup(cmds[i]);
+        apps[i].maxprocs = maxprocs[i];
+        apps[i].argv = pmix_argv_copy((char**) argvs[i]);
+        apps[i].ninfo = info_keyval_sizesp[i];
+        if (0 < apps[i].ninfo) {
+            apps[i].info = (pmix_info_t*)malloc(apps[i].ninfo * sizeof(pmix_info_t));
+            /* copy the info objects */
+            for (j = 0; j < apps[i].ninfo; j++) {
+                pmix_strncpy(apps[i].info[j].key, info_keyval_vectors[i][j].key, PMIX_MAX_KEYLEN);
+                apps[i].info[j].value.type = PMIX_STRING;
+                apps[i].info[j].value.data.string = strdup(info_keyval_vectors[i][j].val);
+            }
+        }
+        /* push the preput values into the apps environ */
+        for (k = 0; k < preput_keyval_size; k++) {
+            if (0 > asprintf(&evar, "%s=%s", preput_keyval_vector[k].key, preput_keyval_vector[k].val)) {
+                for (i = 0; i < count; i++) {
+                    PMIX_APP_DESTRUCT(&apps[i]);
+                }
+                free(apps);
+                return PMIX_ERR_NOMEM;
+            }
+            pmix_argv_append_nosize(&apps[i].env, evar);
+            free(evar);
+        }
+    }
+
+    rc = PMIx_Spawn(NULL, 0, apps, count, NULL);
+    /* tear down the apps array */
+    for (i = 0; i < count; i++) {
+        PMIX_APP_DESTRUCT(&apps[i]);
+    }
+    free(apps);
+    if (NULL != errors) {
+        for (i = 0; i < count; i++) {
+            errors[i] = convert_err(rc);
+        }
+    }
+    return convert_err(rc);
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size)
+{
+    return PMI_FAIL;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size)
+{
+    return PMI_FAIL;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size)
+{
+    return PMI_FAIL;
+}
+
+/* nobody supports this call, which is why it was
+ * dropped for PMI-2 */
+PMIX_EXPORT int PMI_Get_options(char *str, int *length)
+{
+    return PMI_FAIL;
+}
+
+/***   UTILITY FUNCTIONS   ***/
+/* internal function */
+static pmix_status_t convert_int(int *value, pmix_value_t *kv)
+{
+    switch (kv->type) {
+    case PMIX_INT:
+        *value = kv->data.integer;
+        break;
+    case PMIX_INT8:
+        *value = kv->data.int8;
+        break;
+    case PMIX_INT16:
+        *value = kv->data.int16;
+        break;
+    case PMIX_INT32:
+        *value = kv->data.int32;
+        break;
+    case PMIX_INT64:
+        *value = kv->data.int64;
+        break;
+    case PMIX_UINT:
+        *value = kv->data.uint;
+        break;
+    case PMIX_UINT8:
+        *value = kv->data.uint8;
+        break;
+    case PMIX_UINT16:
+        *value = kv->data.uint16;
+        break;
+    case PMIX_UINT32:
+        *value = kv->data.uint32;
+        break;
+    case PMIX_UINT64:
+        *value = kv->data.uint64;
+        break;
+    case PMIX_BYTE:
+        *value = kv->data.byte;
+        break;
+    case PMIX_SIZE:
+        *value = kv->data.size;
+        break;
+    case PMIX_BOOL:
+        *value = kv->data.flag;
+        break;
+    default:
+        /* not an integer type */
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return PMIX_SUCCESS;
+}
+
+static int convert_err(pmix_status_t rc)
+{
+    switch (rc) {
+    case PMIX_ERR_INVALID_SIZE:
+        return PMI_ERR_INVALID_SIZE;
+
+    case PMIX_ERR_INVALID_KEYVALP:
+        return PMI_ERR_INVALID_KEYVALP;
+
+    case PMIX_ERR_INVALID_NUM_PARSED:
+        return PMI_ERR_INVALID_NUM_PARSED;
+
+    case PMIX_ERR_INVALID_ARGS:
+        return PMI_ERR_INVALID_ARGS;
+
+    case PMIX_ERR_INVALID_NUM_ARGS:
+        return PMI_ERR_INVALID_NUM_ARGS;
+
+    case PMIX_ERR_INVALID_LENGTH:
+        return PMI_ERR_INVALID_LENGTH;
+
+    case PMIX_ERR_INVALID_VAL_LENGTH:
+        return PMI_ERR_INVALID_VAL_LENGTH;
+
+    case PMIX_ERR_INVALID_VAL:
+        return PMI_ERR_INVALID_VAL;
+
+    case PMIX_ERR_INVALID_KEY_LENGTH:
+        return PMI_ERR_INVALID_KEY_LENGTH;
+
+    case PMIX_ERR_INVALID_KEY:
+        return PMI_ERR_INVALID_KEY;
+
+    case PMIX_ERR_INVALID_ARG:
+        return PMI_ERR_INVALID_ARG;
+
+    case PMIX_ERR_NOMEM:
+        return PMI_ERR_NOMEM;
+
+    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+    case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
+    case PMIX_ERR_LOST_PEER_CONNECTION:
+    case PMIX_ERR_LOST_CONNECTION_TO_CLIENT:
+    case PMIX_ERR_NOT_SUPPORTED:
+    case PMIX_ERR_NOT_FOUND:
+    case PMIX_ERR_SERVER_NOT_AVAIL:
+    case PMIX_ERR_INVALID_NAMESPACE:
+    case PMIX_ERR_DATA_VALUE_NOT_FOUND:
+    case PMIX_ERR_OUT_OF_RESOURCE:
+    case PMIX_ERR_RESOURCE_BUSY:
+    case PMIX_ERR_BAD_PARAM:
+    case PMIX_ERR_IN_ERRNO:
+    case PMIX_ERR_UNREACH:
+    case PMIX_ERR_TIMEOUT:
+    case PMIX_ERR_NO_PERMISSIONS:
+    case PMIX_ERR_PACK_MISMATCH:
+    case PMIX_ERR_PACK_FAILURE:
+    case PMIX_ERR_UNPACK_FAILURE:
+    case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
+    case PMIX_ERR_TYPE_MISMATCH:
+    case PMIX_ERR_PROC_ENTRY_NOT_FOUND:
+    case PMIX_ERR_UNKNOWN_DATA_TYPE:
+    case PMIX_ERR_WOULD_BLOCK:
+    case PMIX_EXISTS:
+    case PMIX_ERROR:
+        return PMI_FAIL;
+
+    case PMIX_ERR_INIT:
+        return PMI_ERR_INIT;
+
+    case PMIX_SUCCESS:
+        return PMI_SUCCESS;
+    default:
+        return PMI_FAIL;
+    }
+}

--- a/src/pmi1.c
+++ b/src/pmi1.c
@@ -28,14 +28,8 @@
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#include PMIX_EVENT_HEADER
 
 #define ANL_MAPPING "PMI_process_mapping"
-
-#include "src/mca/bfrops/bfrops.h"
-#include "src/util/argv.h"
-#include "src/util/error.h"
-#include "src/util/output.h"
 
 #define PMI_MAX_ID_LEN       PMIX_MAX_NSLEN  /* Maximim size of PMI process group ID */
 #define PMI_MAX_KEY_LEN      PMIX_MAX_KEYLEN /* Maximum size of a PMI key */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+pmi_test

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,0 +1,7 @@
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
+
+bin_PROGRAMS = pmi_test
+pmi_test_LDADD = $(top_builddir)/src/libpmi.la
+pmi_test_SOURCES = pmi_test.c
+

--- a/test/pmi_test.c
+++ b/test/pmi_test.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include "pmi.h"
+
+int main (int argc, char *argv[])
+{
+    int spawned = 0;
+    int rc = 0;
+    int size, rank, appnum;
+    rc = PMI_Init (&spawned);
+    printf ("rc from PMI_Init() is %d\n", rc);
+    rc = PMI_Get_size (&size);
+    printf ("rc from PMI_Get_size() is %d\n", rc);
+    rc = PMI_Get_rank (&rank);
+    printf ("rc from PMI_Get_rank() is %d\n", rc);
+    rc = PMI_Get_appnum (&appnum);
+    printf ("rc from PMI_Get_appnum() is %d\n", rc);
+    rc = PMI_Barrier ();
+    printf ("rc from PMI_Barrier() is %d\n", rc);
+    return 0;
+}


### PR DESCRIPTION
Still a WIP, but I felt like once I hit the minimal working example, I should post a PR to get feedback and make sure I'm not going off the rails already :laughing:

This PR carves out the `pmi1.c` shim from OpenPMIx and builds it in isolation against an external PMIx.  It uses a lightly modified copy of m4 from OpenMPI to find the external PMIx library and set the relevant variables.  Rather than try and pare down OpenMPI's configure.ac, I decide to just piece one together from scratch.  So feel free to holler if I am doing something wonky there.

Still TODO:

- Tie the simple test into `make check`
- Make sure this works with out-of-tree builds, with `make dist`, etc.
- Unwind the deleted `#include`s in `pmi1.c` so that the file in this repo and upstream are identical

Probably for future PRs:

- More rigorous tests
- Setup a CI to run `make check`

Signed-off-by: Stephen Herbein <herbein1@llnl.gov>