### PR TITLE
Replace asprintf with snprintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ config/ltversion.m4
 config/lt~obsolete.m4
 config/missing
 configure
+config/pmishim_get_version.sh~
+configure~
 libtool
 Makefile
 config.status


### PR DESCRIPTION
Some environments seem to object to asprintf, so
replace it with snprintf to silence the complaints